### PR TITLE
fix: enable sort for older versions of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include install.mk
 
 DRY_RUN ?= true
-DIRECTORY = $(notdir $(wildcard packages/*))
+DIRECTORY = $(notdir $(sort $(wildcard packages/*)))
 VALUES ?= values.yaml
 
 DIST_DIR = .dist/


### PR DESCRIPTION
up to make 3.8, wildcard was sorted 
from make 3.9 to 4.2 make did not sort in wildcard
in make 4.3 the behaviour was reverted to the orginal one

:D

In this PR i make sure we always sort such that we dont get different behaviours depending on the make version 